### PR TITLE
Initiales Helm Chart

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -11,3 +11,7 @@ indent_size = 4
 continuation_indent_size = 8
 trim_trailing_whitespace = true
 insert_final_newline = true
+
+[*.yaml]
+indent_size = 2
+indent_style = space

--- a/deployment/kubernetes/charts/svws/Chart.yaml
+++ b/deployment/kubernetes/charts/svws/Chart.yaml
@@ -1,0 +1,3 @@
+apiVersion: v2
+name: svws
+version: 0.9.2

--- a/deployment/kubernetes/charts/svws/templates/deployment.yaml
+++ b/deployment/kubernetes/charts/svws/templates/deployment.yaml
@@ -1,0 +1,49 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ .Values.application.name }}
+  labels:
+    app: {{ .Values.application.name }}
+spec:
+  selector:
+    matchLabels:
+      app: {{ .Values.application.name }}
+  replicas: {{ .Values.deployment.replicas }}
+  template:
+    metadata:
+      labels:
+        app: {{ .Values.application.name }}
+    spec:
+      containers:
+        - name: {{ .Values.application.name }}
+          image: "svwsnrw/svws-server:{{- .Values.application.version }}"
+
+          imagePullPolicy: Always
+          ports:
+            - containerPort: {{ .Values.application.port }}
+          resources:
+            requests:
+              memory: {{ .Values.application.resources.requests.memory }}
+              cpu: {{ .Values.application.resources.requests.cpu }}
+            limits:
+              memory: {{ .Values.application.resources.limits.memory }}
+              cpu: {{ .Values.application.resources.limits.cpu }}
+          env:
+            - name: SVWS_TLS_KEYSTORE_CREATE
+              value: {{ .Values.application.createKeystore }}
+            - name: MariaDB_HOST
+              value: {{ .Values.application.db.host }}
+            - name: MariaDB_DATABASE
+              value: {{ .Values.application.db.database }}
+            - name: MariaDB_USER
+              value: {{ .Values.application.db.user }}
+            - name: MariaDB_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.application.db.existingSecret }}
+                  key: mariadb-root-password
+            - name: MariaDB_ROOT_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.application.db.existingSecret }}
+                  key: mariadb-root-password

--- a/deployment/kubernetes/charts/svws/templates/service.yaml
+++ b/deployment/kubernetes/charts/svws/templates/service.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ .Values.application.name }}
+  labels:
+    app: {{ .Values.application.name }}
+spec:
+  type: ClusterIP
+  selector:
+    app: {{ .Values.application.name }}
+  ports:
+    - port: {{ .Values.application.port }}
+      targetPort: {{ .Values.application.port }}
+      protocol: TCP
+

--- a/deployment/kubernetes/charts/svws/values.yaml
+++ b/deployment/kubernetes/charts/svws/values.yaml
@@ -1,0 +1,28 @@
+application:
+  # Service & Deployment Name
+  name: "svws"
+  # Version des SVWS-Servers
+  version: "0.9.2"
+  # Default port
+  port: "8443"
+  # Setzt SVWS_TLS_KEYSTORE_CREATE
+  createKeystore: "true"
+  resources:
+    # minimal verfügbare Ressourcen auf der kubernetes node
+    requests:
+      memory: "700Mi"
+      cpu: "100m"
+    # Maximaler Ressourcenverbrauch des pods
+    limits:
+      memory: "1Gi"
+      cpu: "500m"
+  # Datenbank konfiguration
+  db:
+    host: "mariadb"
+    database: "gynabi"
+    user: "gynabi"
+    # Existierendes secret für Datenbank-Passwörter
+    existingSecret: "svws-mariadb-secret" # erwartet werden die keys mariadb-root-password & mariadb-root-password
+# Horizontale Skalierung
+deployment:
+  replicas: 1


### PR DESCRIPTION
Helm Chart für deployment in kubernetes mithilfe von helm. 
Das ist aus meinen Versuchen den svws-server testweise in kubernetes zu deployen entstanden.

Fehlen tun noch:
- Keystore über Secret als Volume mounten
- optionaler Reverse Proxy (Traefik)
- optionaler certbot fuer TLS-Zertifikate
- Config für Umgang mit leerer MDB & den init-skripten
