### PR TITLE
Update Dockerfile

### DIFF
--- a/svws-webclient/enmserver/Dockerfile
+++ b/svws-webclient/enmserver/Dockerfile
@@ -18,7 +18,7 @@ a2ensite default-ssl
 sed -ri -e 's!/var/www/html!${APACHE_DOCUMENT_ROOT}!g' /etc/apache2/sites-available/*.conf
 # Setzen der zus. Konfiguration in das conf-Verzeichnis
 echo "<Directory \${ENMROOT}>
-    Options Indexes FollowSymLinks Includes ExecCGI
+    Options Indexes SymLinksIfOwnerMatch Includes ExecCGI
     AllowOverride All
     Require all granted
 </Directory>" > /etc/apache2/conf-enabled/enmserver.conf


### PR DESCRIPTION
Wenn schon FollowSymLinks erforderlich ist (einen Grund dafür sehe ich nicht), dann bitte immer als SymLinksIfOwnerMatch. Siehe auch https://blog.jonaspasche.com/2014/07/11/followsymlinks-vs-symlinksifownermatch/