### PR TITLE
allow symlinks for publicfolder

### DIFF
--- a/svws-webclient/enmserver/src/php/app/Config.php
+++ b/svws-webclient/enmserver/src/php/app/Config.php
@@ -70,7 +70,7 @@
 		 * @return string der absolute Pfad, wo sich die Applikation befindet
 		 */
 		protected static function determineAppRoot(): string {
-			return substr($_SERVER["DOCUMENT_ROOT"], 0, -strlen("/public"));
+			return __DIR__.'/..';
 		}
 
 		/**

--- a/svws-webclient/enmserver/src/php/public/.htaccess
+++ b/svws-webclient/enmserver/src/php/public/.htaccess
@@ -4,6 +4,7 @@ CGIPassAuth on
 	Header set Access-Control-Allow-Origin "*"
 	Header set Access-Control-Allow-Headers "*, Authorization"
 	Header set Access-Control-Allow-Methods "GET, POST, PATCH, PUT, DELETE, OPTIONS, HEAD"
+	Header set X-Robots-Tag "noindex, nofollow"
 </IfModule>
 
 RewriteEngine on

--- a/svws-webclient/enmserver/src/php/public/api/ankreuzkompetenz.php
+++ b/svws-webclient/enmserver/src/php/public/api/ankreuzkompetenz.php
@@ -14,8 +14,8 @@
 	 */
 
 	// Initialisierung
-	require_once $_SERVER['DOCUMENT_ROOT'].'/../app/init.php';
-	require_once $_SERVER['DOCUMENT_ROOT'].'/../app/ENMDatenManager.php';
+	require_once __DIR__.'/../../app/init.php';
+	require_once __DIR__.'/../../app/ENMDatenManager.php';
 
 	// Prüfe die HTTP-Methode
 	$auth->pruefeHTTPMethod([ "POST" ]);

--- a/svws-webclient/enmserver/src/php/public/api/bemerkungen.php
+++ b/svws-webclient/enmserver/src/php/public/api/bemerkungen.php
@@ -15,8 +15,8 @@
  	 */
 
 	// Initialisierung
-	require_once $_SERVER['DOCUMENT_ROOT'].'/../app/init.php';
-	require_once $_SERVER['DOCUMENT_ROOT'].'/../app/ENMDatenManager.php';
+	require_once __DIR__.'/../../app/init.php';
+	require_once __DIR__.'/../../app/ENMDatenManager.php';
 
 	// Prüfe die HTTP-Methode
 	$auth->pruefeHTTPMethod([ "POST" ]);

--- a/svws-webclient/enmserver/src/php/public/api/check_smtp.php
+++ b/svws-webclient/enmserver/src/php/public/api/check_smtp.php
@@ -13,7 +13,7 @@
 	 */
 
 	// Initialisierung
-	require_once $_SERVER['DOCUMENT_ROOT'].'/../app/init.php';
+	require_once __DIR__.'/../../app/init.php';
 
 	// Prüfe die HTTP-Methode
 	$auth->pruefeHTTPMethod(["GET"]);

--- a/svws-webclient/enmserver/src/php/public/api/clientconfig.php
+++ b/svws-webclient/enmserver/src/php/public/api/clientconfig.php
@@ -18,7 +18,7 @@
 	 */
 
 	// Initialisierung
-	require_once $_SERVER['DOCUMENT_ROOT'].'/../app/init.php';
+	require_once __DIR__.'/../../app/init.php';
 
 	// Prüfe die HTTP-Methode
 	$auth->pruefeHTTPMethod([ "GET", "PUT" ]);

--- a/svws-webclient/enmserver/src/php/public/api/create_pwt.php
+++ b/svws-webclient/enmserver/src/php/public/api/create_pwt.php
@@ -16,7 +16,7 @@
 	 * @responseCode 429 Zu viele Anfragen, falls bereits ein gültiges Token existiert.
 	 */
 
-	require_once $_SERVER['DOCUMENT_ROOT'].'/../app/init.php';
+	require_once __DIR__.'/../../app/init.php';
 	
 	// Prüfe die HTTP-Methode
 	$auth->pruefeHTTPMethod([ "POST" ]);

--- a/svws-webclient/enmserver/src/php/public/api/daten.php
+++ b/svws-webclient/enmserver/src/php/public/api/daten.php
@@ -9,8 +9,8 @@
 	 */
 
 	// Initialisierung
-	require_once $_SERVER['DOCUMENT_ROOT'].'/../app/init.php';
-	require_once $_SERVER['DOCUMENT_ROOT'].'/../app/ENMDatenManager.php';
+	require_once __DIR__.'/../../app/init.php';
+	require_once __DIR__.'/../../app/ENMDatenManager.php';
 
 	// Prüfe die HTTP-Methode
 	$auth->pruefeHTTPMethod([ "GET" ]);

--- a/svws-webclient/enmserver/src/php/public/api/leistung.php
+++ b/svws-webclient/enmserver/src/php/public/api/leistung.php
@@ -14,8 +14,8 @@
 	 */
 
 	// Initialisierung
-	require_once $_SERVER['DOCUMENT_ROOT'].'/../app/init.php';
-	require_once $_SERVER['DOCUMENT_ROOT'].'/../app/ENMDatenManager.php';
+	require_once __DIR__.'/../../app/init.php';
+	require_once __DIR__.'/../../app/ENMDatenManager.php';
 
 	// Prüfe die HTTP-Methode
 	$auth->pruefeHTTPMethod([ "POST" ]);

--- a/svws-webclient/enmserver/src/php/public/api/lernabschnitt.php
+++ b/svws-webclient/enmserver/src/php/public/api/lernabschnitt.php
@@ -12,8 +12,8 @@
 	 */
 
 	// Initialisierung
-	require_once $_SERVER['DOCUMENT_ROOT'] . '/../app/init.php';
-	require_once $_SERVER['DOCUMENT_ROOT'] . '/../app/ENMDatenManager.php';
+	require_once __DIR__.'/../../app/init.php';
+	require_once __DIR__.'/../../app/ENMDatenManager.php';
 
 	// Prüfe die HTTP-Methode
 	$auth->pruefeHTTPMethod([ "POST" ]);

--- a/svws-webclient/enmserver/src/php/public/api/mode.php
+++ b/svws-webclient/enmserver/src/php/public/api/mode.php
@@ -10,7 +10,7 @@
 	 */
 
 	// Initialisierung
-	require_once $_SERVER['DOCUMENT_ROOT'].'/../app/init.php';
+	require_once __DIR__.'/../../app/init.php';
 
 	// Prüfe die HTTP-Methode
 	$auth->pruefeHTTPMethod([ "GET" ]);

--- a/svws-webclient/enmserver/src/php/public/api/reset_password.php
+++ b/svws-webclient/enmserver/src/php/public/api/reset_password.php
@@ -17,7 +17,7 @@
 	 * @responseCode 409 Fehlerhafte Anfrage, wenn Token ungültig oder Passwort nicht regelkonform ist.
 	 */
 	// Initialisierung
-	require_once $_SERVER['DOCUMENT_ROOT'].'/../app/init.php';
+	require_once __DIR__.'/../../app/init.php';
 
 	// Prüfe die HTTP-Methode
 	$auth->pruefeHTTPMethod(["PUT"]);

--- a/svws-webclient/enmserver/src/php/public/api/secure/check.php
+++ b/svws-webclient/enmserver/src/php/public/api/secure/check.php
@@ -9,7 +9,7 @@
 	 */
 
 	// Initialisierung
-	require_once $_SERVER['DOCUMENT_ROOT'].'/../app/init.php';
+	require_once __DIR__.'/../../../app/init.php';
 
 	// Prüfe die HTTP-Methode
 	$auth->pruefeHTTPMethod([ "GET" ]);

--- a/svws-webclient/enmserver/src/php/public/api/secure/export.php
+++ b/svws-webclient/enmserver/src/php/public/api/secure/export.php
@@ -10,8 +10,8 @@
 	 */
 
 	// Initialisierung
-	require_once $_SERVER['DOCUMENT_ROOT'].'/../app/init.php';
-	require_once $_SERVER['DOCUMENT_ROOT'].'/../app/ENMDatenManager.php';
+	require_once __DIR__.'/../../../app/init.php';
+	require_once __DIR__.'/../../../app/ENMDatenManager.php';
 
 	// Prüfe die HTTP-Methode
 	$auth->pruefeHTTPMethod([ "GET" ]);

--- a/svws-webclient/enmserver/src/php/public/api/secure/import.php
+++ b/svws-webclient/enmserver/src/php/public/api/secure/import.php
@@ -9,8 +9,8 @@
 	 * @responseCode 200
 	 */
 	// Initialisierung
-	require_once $_SERVER['DOCUMENT_ROOT'].'/../app/init.php';
-	require_once $_SERVER['DOCUMENT_ROOT'].'/../app/ENMDatenManager.php';
+	require_once __DIR__.'/../../../app/init.php';
+	require_once __DIR__.'/../../../app/ENMDatenManager.php';
 
 	// Prüfe die HTTP-Methode
 	$auth->pruefeHTTPMethod([ "POST" ]);

--- a/svws-webclient/enmserver/src/php/public/api/secure/reset.php
+++ b/svws-webclient/enmserver/src/php/public/api/secure/reset.php
@@ -9,8 +9,8 @@
 	 * @responseCode 200
 	 */
 	// Initialisierung
-	require_once $_SERVER['DOCUMENT_ROOT'].'/../app/init.php';
-	require_once $_SERVER['DOCUMENT_ROOT'].'/../app/ENMDatenManager.php';
+	require_once __DIR__.'/../../../app/init.php';
+	require_once __DIR__.'/../../../app/ENMDatenManager.php';
 
 	// Prüfe die HTTP-Methode
 	$auth->pruefeHTTPMethod([ "POST" ]);

--- a/svws-webclient/enmserver/src/php/public/api/secure/serverconfig.php
+++ b/svws-webclient/enmserver/src/php/public/api/secure/serverconfig.php
@@ -17,7 +17,7 @@
 	 * @responseCode 500 Error Falls HTTP Methode weder GET noch PUT ist
  */
 	// Initialisierung
-	require_once $_SERVER['DOCUMENT_ROOT'].'/../app/init.php';
+	require_once __DIR__.'/../../../app/init.php';
 
 	// Prüfe die HTTP-Methode
 	$auth->pruefeHTTPMethod([ "GET", "PUT" ]);

--- a/svws-webclient/enmserver/src/php/public/api/secure/sync.php
+++ b/svws-webclient/enmserver/src/php/public/api/secure/sync.php
@@ -10,8 +10,8 @@
 	 */
 
 	// Initialisierung
-	require_once $_SERVER['DOCUMENT_ROOT'].'/../app/init.php';
-	require_once $_SERVER['DOCUMENT_ROOT'].'/../app/ENMDatenManager.php';
+	require_once __DIR__.'/../../../app/init.php';
+	require_once __DIR__.'/../../../app/ENMDatenManager.php';
 
 	// Prüfe die HTTP-Methode
 	$auth->pruefeHTTPMethod([ "POST" ]);

--- a/svws-webclient/enmserver/src/php/public/api/secure/truncate.php
+++ b/svws-webclient/enmserver/src/php/public/api/secure/truncate.php
@@ -10,8 +10,8 @@
 	 */
 
 	// Initialisierung
-	require_once $_SERVER['DOCUMENT_ROOT'].'/../app/init.php';
-	require_once $_SERVER['DOCUMENT_ROOT'].'/../app/ENMDatenManager.php';
+	require_once __DIR__.'/../../../app/init.php';
+	require_once __DIR__.'/../../../app/ENMDatenManager.php';
 
 	// Prüfe die HTTP-Methode
 	$auth->pruefeHTTPMethod([ "POST" ]);

--- a/svws-webclient/enmserver/src/php/public/api/setup.php
+++ b/svws-webclient/enmserver/src/php/public/api/setup.php
@@ -12,8 +12,8 @@
 	 * @responseCode 409 Falls der Server bereits initiiert wurde
  	 */
 
-	require_once $_SERVER['DOCUMENT_ROOT'].'/../app/Config.php';
-	require_once $_SERVER['DOCUMENT_ROOT'].'/../app/Database.php';
+	require_once __DIR__.'/../../app/Config.php';
+	require_once __DIR__.'/../../app/Database.php';
 
 	if (strcmp($_SERVER['REQUEST_METHOD'], 'GET') !== 0) {
 		http_response_code(403);

--- a/svws-webclient/enmserver/src/php/public/api/teilleistung.php
+++ b/svws-webclient/enmserver/src/php/public/api/teilleistung.php
@@ -12,8 +12,8 @@
 	 */
 
 	// Initialisierung
-	require_once $_SERVER['DOCUMENT_ROOT'].'/../app/init.php';
-	require_once $_SERVER['DOCUMENT_ROOT'].'/../app/ENMDatenManager.php';
+	require_once __DIR__.'/../../app/init.php';
+	require_once __DIR__.'/../../app/ENMDatenManager.php';
 
 	// Prüfe die HTTP-Methode
 	$auth->pruefeHTTPMethod([ "POST" ]);

--- a/svws-webclient/enmserver/src/php/public/oauth/token.php
+++ b/svws-webclient/enmserver/src/php/public/oauth/token.php
@@ -13,7 +13,7 @@
 	 * @return void
 	 */
 
-	require_once $_SERVER['DOCUMENT_ROOT'].'/../app/init.php';
+	require_once __DIR__.'/../../../app/init.php';
 
 	// Prüfe die HTTP-Methode ...
 	$auth->pruefeHTTPMethod([ "POST" ]);


### PR DESCRIPTION
Some ISPs (eg us) don't allow free changing of DocumentRoot of VirtualHosts to Subdirectories but require a static naming scheme (e.g. directory /home/example/svws.example.com for a VirtualHost named svws.example.com.

By using symlinks you can then instead point the DocumentRoot to a Subdirectory but this requires app_root-Detection to not rely on (wrongly set) $_SERVER['DOCUMENT_ROOT'] but instead use __DIR__ to find the right directory.

```
drwxr-xr-x  6 usr grp 4096 May  7 12:11 notenmodul
drwxr-xr-x 2 usr grp   4096 May  7 12:57 notenmodul/app
drwxr-xr-x 2 usr grp   4096 May  7 12:53 notenmodul/db
drwxr-xr-x 5 usr grp   4096 May  7 12:18 notenmodul/public
lrwxrwxrwx  1 usr grp   17 May  7 12:10 svws.example.com -> notenmodul/public
```