### PR TITLE
Alle Wrapper-Klassen für primitive Datentypen (bspw. Character, Boole…

### DIFF
--- a/svws-openapi/src/main/java/de/svws_nrw/api/OpenApiServer.java
+++ b/svws-openapi/src/main/java/de/svws_nrw/api/OpenApiServer.java
@@ -3,6 +3,8 @@ package de.svws_nrw.api;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
+import de.svws_nrw.api.swagger.NonPrimitiveToNullableConverter;
+import io.swagger.v3.core.converter.ModelConverters;
 import org.apache.commons.lang3.StringUtils;
 
 import com.fasterxml.jackson.core.util.DefaultPrettyPrinter;
@@ -113,8 +115,10 @@ public class OpenApiServer extends BaseOpenApiResource {
 	public Response getOpenApi(@Context final HttpHeaders headers,
 			@Context final UriInfo uriInfo,
 			@PathParam("type") final String type) throws Exception {
+		ModelConverters.getInstance().addConverter(new NonPrimitiveToNullableConverter());
 		final OpenApiContext ctx = getOpenApiContext();
 		final OpenAPI oas = ctx.read();
+
 		if (oas == null)
 			return Response.status(404).build();
 

--- a/svws-openapi/src/main/java/de/svws_nrw/api/swagger/NonPrimitiveToNullableConverter.java
+++ b/svws-openapi/src/main/java/de/svws_nrw/api/swagger/NonPrimitiveToNullableConverter.java
@@ -14,17 +14,6 @@ import org.apache.commons.lang3.ClassUtils;
 
 public class NonPrimitiveToNullableConverter implements ModelConverter {
 
-	private static final Class<?>[] PrimitiveObjectTypes = {
-			Boolean.class,
-			Byte.class,
-			Character.class,
-			Float.class,
-			Integer.class,
-			Long.class,
-			Short.class,
-			Double.class
-	};
-
 	@Override
 	public final Schema resolve(final AnnotatedType annotatedType, final ModelConverterContext modelConverterContext, final Iterator<ModelConverter> iterator) {
 		if (iterator.hasNext()) {
@@ -32,13 +21,12 @@ public class NonPrimitiveToNullableConverter implements ModelConverter {
 			final Schema model = converter.resolve(annotatedType, modelConverterContext, iterator);
 
 			if (model != null) {
-				final var javaType = Json.mapper().constructType(annotatedType.getType());
-				final var clazz = javaType.getRawClass();
-
 				final var isPropertyDefinedAsNotNull =
 						(annotatedType.getCtxAnnotations() != null) && Arrays.stream(annotatedType.getCtxAnnotations()).anyMatch(x -> x instanceof NotNull);
 
-				if (ClassUtils.isPrimitiveWrapper(clazz) && (model.getNullable() == null) && !isPropertyDefinedAsNotNull) {
+				final JavaType javaType = Json.mapper().constructType(annotatedType.getType());
+
+				if (ClassUtils.isPrimitiveWrapper(javaType.getRawClass()) && (model.getNullable() == null) && !isPropertyDefinedAsNotNull) {
 					model.setNullable(true);
 				}
 

--- a/svws-openapi/src/main/java/de/svws_nrw/api/swagger/NonPrimitiveToNullableConverter.java
+++ b/svws-openapi/src/main/java/de/svws_nrw/api/swagger/NonPrimitiveToNullableConverter.java
@@ -1,0 +1,56 @@
+package de.svws_nrw.api.swagger;
+
+import java.util.Arrays;
+import java.util.Iterator;
+
+import com.fasterxml.jackson.databind.JavaType;
+import io.swagger.v3.core.converter.AnnotatedType;
+import io.swagger.v3.core.converter.ModelConverter;
+import io.swagger.v3.core.converter.ModelConverterContext;
+import io.swagger.v3.core.util.Json;
+import io.swagger.v3.oas.models.media.Schema;
+import jakarta.validation.constraints.NotNull;
+import org.apache.commons.lang3.ClassUtils;
+
+public class NonPrimitiveToNullableConverter implements ModelConverter {
+
+	private static final Class<?>[] PrimitiveObjectTypes = {
+			Boolean.class,
+			Byte.class,
+			Character.class,
+			Float.class,
+			Integer.class,
+			Long.class,
+			Short.class,
+			Double.class
+	};
+
+	@Override
+	public final Schema resolve(final AnnotatedType annotatedType, final ModelConverterContext modelConverterContext, final Iterator<ModelConverter> iterator) {
+		if (iterator.hasNext()) {
+			final ModelConverter converter = iterator.next();
+			final Schema model = converter.resolve(annotatedType, modelConverterContext, iterator);
+
+			if (model != null) {
+				final var javaType = Json.mapper().constructType(annotatedType.getType());
+				final var clazz = javaType.getRawClass();
+
+				final var isPropertyDefinedAsNotNull =
+						(annotatedType.getCtxAnnotations() != null) && Arrays.stream(annotatedType.getCtxAnnotations()).anyMatch(x -> x instanceof NotNull);
+
+				if (ClassUtils.isPrimitiveWrapper(clazz) && (model.getNullable() == null) && !isPropertyDefinedAsNotNull) {
+					model.setNullable(true);
+				}
+
+				return model;
+			}
+		}
+
+		return null;
+	}
+
+	@Override
+	public final boolean isOpenapi31() {
+		return ModelConverter.super.isOpenapi31();
+	}
+}

--- a/svws-openapi/src/main/java/de/svws_nrw/api/swagger/NonPrimitiveToNullableConverter.java
+++ b/svws-openapi/src/main/java/de/svws_nrw/api/swagger/NonPrimitiveToNullableConverter.java
@@ -21,7 +21,7 @@ public class NonPrimitiveToNullableConverter implements ModelConverter {
 			final Schema model = converter.resolve(annotatedType, modelConverterContext, iterator);
 
 			if (model != null) {
-				final var isPropertyDefinedAsNotNull =
+				final boolean isPropertyDefinedAsNotNull =
 						(annotatedType.getCtxAnnotations() != null) && Arrays.stream(annotatedType.getCtxAnnotations()).anyMatch(x -> x instanceof NotNull);
 
 				final JavaType javaType = Json.mapper().constructType(annotatedType.getType());


### PR DESCRIPTION
…an, Integer, Double usw.) werden automatisch als `nullable` in der OpenAPI Spezifikation definiert, sofern nicht eine @NotNull Annotation vorhanden ist oder die `nullable` Eigenschaft bereits über die OpenAPI-Annotation gesetzt wurde (closes #393)