### PR TITLE
Backport MARIADB Variables for Compatibility

### DIFF
--- a/deployment/docker/svws/Dockerfile
+++ b/deployment/docker/svws/Dockerfile
@@ -5,8 +5,8 @@ RUN apt update && apt-get -y upgrade && apt-get -y install gettext zip && apt au
 RUN mkdir -p /opt/app/svws/client && mkdir /opt/app/svws/conf && mkdir /opt/app/svws/init
 
 COPY app /opt/app/svws
-COPY svwsconfig-template.json /opt/app/svws/svwsconfig-template.json
-COPY svwsconfig-template-nodb.json /opt/app/svws/svwsconfig-template-nodb.json
+COPY svwsconfig-template.json /opt/app/svws/templates/svwsconfig-template.json
+COPY svwsconfig-template-nodb.json /opt/app/svws/templates/svwsconfig-template-nodb.json
 COPY startup.sh /opt/app/svws/startup.sh
 
 RUN unzip -d /opt/app/svws/client /opt/app/svws/SVWS-Client*.zip && rm -rf /opt/app/svws/SVWS-Client*.zip && unzip -d /opt/app/svws/adminclient /opt/app/svws/SVWS-Admin-Client*.zip && rm -rf /opt/app/svws/SVWS-Admin-Client*.zip

--- a/deployment/docker/svws/startup.sh
+++ b/deployment/docker/svws/startup.sh
@@ -3,6 +3,10 @@
 # Wechsle in das Verzeichnis mit der Konfiguration von wo aus der Server gestartet wird
 cd conf
 
+MARIADB_DATABASE=${MariaDB_DATABASE}
+MARIADB_USER=${MariaDB_USER}
+MARIADB_PASSWORD=${MariaDB_PASSWORD}
+
 # Konfigurationsdatei generieren, wenn nicht vorhanden
 if [[ ! -s /opt/app/svws/conf/svwsconfig.json ]];  then
     echo "Konfigurationsdatei '/opt/app/svws/conf/svwsconfig.json' nicht vorhanden. Erstelle Konfigurationsdatei..."
@@ -24,6 +28,15 @@ if [[ ! -s ${SVWS_TLS_KEYSTORE_PATH}/keystore ]]; then
 	keytool -genkey -noprompt -alias ${SVWS_TLS_KEY_ALIAS} -dname "CN=$SVWS_TLS_CERT_CN, OU=$SVWS_TLS_CERT_OU, O=$SVWS_TLS_CERT_O, L=$SVWS_TLS_CERT_L, S=$SVWS_TLS_CERT_S, C=$SVWS_TLS_CERT_C" -keystore ${SVWS_TLS_KEYSTORE_PATH}/keystore -storepass ${SVWS_TLS_KEYSTORE_PASSWORD} -keypass ${SVWS_TLS_KEYSTORE_PASSWORD} -keyalg RSA
 else
 	echo "Keystore vorhanden."
+fi
+
+# INIT-Scripts starten
+if [[ -d $INIT_SCRIPTS_DIR ]]; then
+    echo "INIT_SCRIPTS_DIR: $INIT_SCRIPTS_DIR"
+        for f in "$INIT_SCRIPTS_DIR"/*.sh; do
+          echo "Starte Shell script: $f"
+          /bin/bash "$f"
+        done
 fi
 
 # Testdatenbank importieren


### PR DESCRIPTION
Introduce MARIADB variables for compatibility with versions prior to 1.0.9 and reorganize configuration template files. Additionally, implement a mechanism to execute initialization scripts if present.

PR to Issue https://github.com/SVWS-NRW/SVWS-Server/issues/429