### PR TITLE
Performance-Optimierung: REST-Authentifizierung und Verbindungsvalidierung

### DIFF
--- a/svws-db-utils/src/main/java/de/svws_nrw/data/benutzer/BenutzerApiPrincipal.java
+++ b/svws-db-utils/src/main/java/de/svws_nrw/data/benutzer/BenutzerApiPrincipal.java
@@ -2,6 +2,9 @@ package de.svws_nrw.data.benutzer;
 
 import java.io.Serializable;
 import java.security.Principal;
+import java.util.ArrayList;
+
+import de.svws_nrw.asd.data.schule.SchuleStammdaten;
 
 import de.svws_nrw.config.SVWSKonfiguration;
 import de.svws_nrw.core.logger.Logger;
@@ -220,6 +223,26 @@ public final class BenutzerApiPrincipal implements Principal, Serializable {
 			// Setze den übergebene Benutzername und das Kennwort auch für die Datenbankverbindung, falls die DB-Konfiguration eine Anmeldung per SVWS-Benutzer vorsieht
 			config = config.switchUser(PersistenceUnits.SVWS_DB, username, password);
 		}
+
+		// Prüfe den Authentifizierungs-Cache, um wiederholte DB-Abfragen bei identischen Anmeldedaten zu vermeiden
+		final BenutzerAuthCache.CacheEntry cachedAuth = BenutzerAuthCache.get(schema, username, password);
+		if (cachedAuth != null) {
+			final Benutzer cachedUser = Benutzer.create(config);
+			cachedUser.setUsername(cachedAuth.correctedUsername());
+			cachedUser.setPassword(password);
+			cachedUser.setId(cachedAuth.userId());
+			cachedUser.setIdLehrer(cachedAuth.idLehrer());
+			cachedUser.setAES();
+			if (cachedAuth.stammdaten() != null) {
+				cachedUser.schuleSetStammdaten(cachedAuth.stammdaten());
+			}
+			cachedUser.setKompetenzen(new ArrayList<>(cachedAuth.kompetenzen()));
+			cachedUser.setKlassenIDs(cachedAuth.klassenIDs());
+			cachedUser.setLeitungsfunktionen(cachedAuth.leitungsfunktionen());
+			cachedUser.setAbiturjahrgaenge(cachedAuth.abiturjahrgaenge());
+			return new BenutzerApiPrincipal(cachedUser);
+		}
+
 		try {
 			final Benutzer user = Benutzer.create(config);
 			user.setUsername(username);
@@ -236,8 +259,10 @@ public final class BenutzerApiPrincipal implements Principal, Serializable {
 			user.setAES();
 
 			// Lese die Stammdaten der Schule ein und setze diese beim Benutzer-Objekt
+			SchuleStammdaten loadedStammdaten = null;
 			try (DBEntityManager conn = user.getEntityManager()) {
-				user.schuleSetStammdaten(DataSchuleStammdaten.getStammdaten(conn));
+				loadedStammdaten = DataSchuleStammdaten.getStammdaten(conn);
+				user.schuleSetStammdaten(loadedStammdaten);
 			} catch (@SuppressWarnings("unused") final ApiOperationException aoe) {
 				Logger.global().logLn(
 						"Es können bei der Anmeldung noch keine Daten zur Schule eingelesen werden. Bitte prüfen Sie, ob das Schema \"%s\" bereits initialisiert wurde."
@@ -246,6 +271,11 @@ public final class BenutzerApiPrincipal implements Principal, Serializable {
 
 			// Lese die Benutzerkompetenzen aus der Datenbank
 			DBBenutzerUtils.leseKompetenzen(user);
+
+
+			// Speichere das Authentifizierungsergebnis im Cache
+			BenutzerAuthCache.put(schema, username, password, user.getUsername(), user.getId(), user.getIdLehrer(),
+					user.getKompetenzen(), loadedStammdaten, user.getKlassenIDs(), user.getLeitungsfunktionen(), user.getAbiturjahrgaenge());
 
 			return new BenutzerApiPrincipal(user);
 		} catch (@SuppressWarnings("unused") final DBException de) {

--- a/svws-db-utils/src/main/java/de/svws_nrw/data/benutzer/BenutzerAuthCache.java
+++ b/svws-db-utils/src/main/java/de/svws_nrw/data/benutzer/BenutzerAuthCache.java
@@ -1,0 +1,160 @@
+package de.svws_nrw.data.benutzer;
+
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.HashSet;
+import java.util.HexFormat;
+import java.util.List;
+import java.util.Locale;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+
+import de.svws_nrw.asd.data.schule.SchuleStammdaten;
+import de.svws_nrw.asd.types.lehrer.LehrerLeitungsfunktion;
+import de.svws_nrw.core.types.benutzer.BenutzerKompetenz;
+
+
+/**
+ * In-memory cache for authenticated user data to avoid repeated DB queries
+ * for authentication on every REST request. Entries expire after a configurable TTL.
+ *
+ * This cache is keyed by (schema, username) and stores the password's SHA-256 hash
+ * for fast credential verification on subsequent requests.
+ */
+public final class BenutzerAuthCache {
+
+	/** Cache TTL in milliseconds (default: 5 minutes) */
+	private static final long CACHE_TTL_MS = 5L * 60 * 1000;
+
+	/** The cache storage */
+	private static final ConcurrentHashMap<String, CacheEntry> cache = new ConcurrentHashMap<>();
+
+	private BenutzerAuthCache() {
+		throw new IllegalStateException("Instantiation of " + BenutzerAuthCache.class.getName() + " not allowed");
+	}
+
+	/**
+	 * A cached authentication result containing all data needed to reconstruct
+	 * an authenticated {@link de.svws_nrw.db.Benutzer} without DB queries.
+	 */
+	public record CacheEntry(
+		String passwordSha256,
+		String correctedUsername,
+		Long userId,
+		Long idLehrer,
+		List<BenutzerKompetenz> kompetenzen,
+		SchuleStammdaten stammdaten,
+		Set<Long> klassenIDs,
+		Set<LehrerLeitungsfunktion> leitungsfunktionen,
+		Set<Integer> abiturjahrgaenge,
+		long createdAt
+	) {}
+
+	/**
+	 * Creates a cache key from schema and username (case-insensitive).
+	 */
+	private static String cacheKey(final String schema, final String username) {
+		return schema + "\0" + username.toLowerCase(Locale.GERMAN);
+	}
+
+	/**
+	 * Computes the SHA-256 hash of a password string for fast comparison.
+	 */
+	private static String hashPassword(final String password) {
+		try {
+			final MessageDigest digest = MessageDigest.getInstance("SHA-256");
+			final byte[] hash = digest.digest(password.getBytes(StandardCharsets.UTF_8));
+			return HexFormat.of().formatHex(hash);
+		} catch (final NoSuchAlgorithmException e) {
+			throw new IllegalStateException("SHA-256 not available", e);
+		}
+	}
+
+	/**
+	 * Looks up a cached authentication entry. Returns the entry only if:
+	 * - An entry exists for the given schema/username
+	 * - The entry has not expired (TTL check)
+	 * - The password's SHA-256 matches the cached hash
+	 *
+	 * @param schema    the database schema name
+	 * @param username  the username
+	 * @param password  the plaintext password to verify against cached hash
+	 *
+	 * @return the cached entry if found and valid, null otherwise
+	 */
+	public static CacheEntry get(final String schema, final String username, final String password) {
+		if ((schema == null) || (username == null) || (password == null))
+			return null;
+		final String key = cacheKey(schema, username);
+		final CacheEntry entry = cache.get(key);
+		if (entry == null)
+			return null;
+		if (System.currentTimeMillis() - entry.createdAt > CACHE_TTL_MS) {
+			cache.remove(key);
+			return null;
+		}
+		if (!hashPassword(password).equals(entry.passwordSha256))
+			return null;
+		return entry;
+	}
+
+	/**
+	 * Stores an authentication result in the cache. All collection parameters
+	 * are defensively copied to ensure thread safety.
+	 *
+	 * @param schema              the database schema name
+	 * @param username            the username (used for cache key)
+	 * @param password            the plaintext password (SHA-256 is stored, not the plaintext)
+	 * @param correctedUsername   the case-corrected username from the DB
+	 * @param userId              the database ID of the user
+	 * @param idLehrer            the teacher ID, or null
+	 * @param kompetenzen         the user's competencies
+	 * @param stammdaten          the school master data, or null
+	 * @param klassenIDs          the class IDs for function-based access
+	 * @param leitungsfunktionen  the leadership functions
+	 * @param abiturjahrgaenge    the Abitur cohort years
+	 */
+	public static void put(final String schema, final String username, final String password,
+			final String correctedUsername, final Long userId, final Long idLehrer,
+			final List<BenutzerKompetenz> kompetenzen, final SchuleStammdaten stammdaten,
+			final Collection<Long> klassenIDs, final Collection<LehrerLeitungsfunktion> leitungsfunktionen,
+			final Collection<Integer> abiturjahrgaenge) {
+		if ((schema == null) || (username == null) || (password == null))
+			return;
+		final String key = cacheKey(schema, username);
+		cache.put(key, new CacheEntry(
+				hashPassword(password),
+				correctedUsername,
+				userId,
+				idLehrer,
+				new ArrayList<>(kompetenzen),
+				stammdaten,
+				new HashSet<>(klassenIDs),
+				new HashSet<>(leitungsfunktionen),
+				new HashSet<>(abiturjahrgaenge),
+				System.currentTimeMillis()
+		));
+	}
+
+	/**
+	 * Removes a cached entry for a specific schema and username.
+	 *
+	 * @param schema    the database schema name
+	 * @param username  the username
+	 */
+	public static void invalidate(final String schema, final String username) {
+		if ((schema != null) && (username != null))
+			cache.remove(cacheKey(schema, username));
+	}
+
+	/**
+	 * Clears all cached entries.
+	 */
+	public static void clear() {
+		cache.clear();
+	}
+
+}

--- a/svws-db/src/main/java/de/svws_nrw/db/ConnectionManager.java
+++ b/svws-db/src/main/java/de/svws_nrw/db/ConnectionManager.java
@@ -1,10 +1,6 @@
 package de.svws_nrw.db;
 
-import java.sql.Connection;
-import java.sql.ResultSet;
-import java.sql.SQLException;
 import java.sql.SQLInvalidAuthorizationSpecException;
-import java.sql.Statement;
 import java.util.HashMap;
 import java.util.List;
 import java.util.concurrent.locks.ReentrantLock;
@@ -36,6 +32,13 @@ public final class ConnectionManager {
 
 	/** Eine HashMap für den schnellen Zugriff auf eine Connection-Factory anhand der Datenbank-Konfiguration */
 	private final HashMap<DBConfig, ConnectionFactory> mapFactories = new HashMap<>();
+
+	/** Zeitstempel der letzten erfolgreichen Verbindungsprüfung pro Factory */
+	private final HashMap<DBConfig, Long> mapLastValidation = new HashMap<>();
+
+	/** Intervall zwischen Verbindungsprüfungen in Millisekunden (30 Sekunden) */
+	private static final long VALIDATION_INTERVAL_MS = 30_000L;
+
 
 	/** Die Instanz des Connectiion-Managers */
 	public static final ConnectionManager instance;
@@ -128,42 +131,38 @@ public final class ConnectionManager {
 				throw pe;
 			}
 		} else {
-			// Führe eine Dummy-DB-Abfrage aus, um Probleme mit der
-			// Server-seitigen Beendung einer Verbindung zu erkennen
-			try {
-				try (EntityManager em = factory.getNewJPAEntityManager()) {
-					try {
-						em.getTransaction().begin();
-						@SuppressWarnings("resource") final Connection conn = em.unwrap(Connection.class);
-						try (Statement stmt = conn.createStatement()) {
-							try (ResultSet rs = stmt.executeQuery("SELECT 1")) {
-								rs.next();
-								rs.getInt(1);
+			// Ratenbegrenzung: Prüfe die Verbindung nur alle VALIDATION_INTERVAL_MS Millisekunden
+			final long now = System.currentTimeMillis();
+			final Long lastValidation = mapLastValidation.get(config);
+			if ((lastValidation == null) || (now - lastValidation > VALIDATION_INTERVAL_MS)) {
+				// Leichtgewichtige Prüfung der Verbindung: SELECT 1 ohne Transaktion
+				try {
+					try (EntityManager em = factory.getNewJPAEntityManager()) {
+						try {
+							em.createNativeQuery("SELECT 1").getSingleResult();
+							mapLastValidation.put(config, now);
+						} catch (@SuppressWarnings("unused") final PersistenceException | DatabaseException e) {
+							// Bestimme die Anzahl der verfügbaren Verbindungen
+							final ServerSession serverSession = em.unwrap(ServerSession.class);
+							final ConnectionPool pool = serverSession.getConnectionPools().get("default");
+							if (pool == null) {
+								Logger.global().logLn(LogLevel.ERROR, "Fehler beim Zugriff auf den DB-Connection-Pool default");
+							} else {
+								Logger.global().logLn(LogLevel.ERROR, "INFO: Verbindung zur Datenbank unterbrochen - versuche sie neu aufzubauen...");
+								Logger.global().logLn(LogLevel.ERROR, "Total number of connections: " + pool.getTotalNumberOfConnections());
+								Logger.global().logLn(LogLevel.ERROR, "Available number of connections: " + pool.getConnectionsAvailable().size());
+								pool.resetConnections();
 							}
 						}
-						em.getTransaction().commit();
-						em.clear();
-					} catch (@SuppressWarnings("unused") SQLException | DatabaseException e) {
-						// Bestimme die Anzahl der verfügbaren Verbindungen
-						final ServerSession serverSession = em.unwrap(ServerSession.class);
-						final ConnectionPool pool = serverSession.getConnectionPools().get("default");
-						if (pool == null) {
-							Logger.global().logLn(LogLevel.ERROR, "Fehler beim Zugriff auf den DB-Connection-Pool default");
-						} else {
-							Logger.global().logLn(LogLevel.ERROR, "INFO: Verbindung zur Datenbank unterbrochen - versuche sie neu aufzubauen...");
-							Logger.global().logLn(LogLevel.ERROR, "Total number of connections: " + pool.getTotalNumberOfConnections());
-							Logger.global().logLn(LogLevel.ERROR, "Available number of connections: " + pool.getConnectionsAvailable().size());
-							pool.resetConnections();
-						}
 					}
+				} catch (final PersistenceException pe) {
+					if ((pe.getCause() instanceof final DatabaseException de) && (de.getCause() instanceof final SQLInvalidAuthorizationSpecException ae)) {
+						mapFactories.remove(config);
+						factory.close();
+						throw new DBException(ae);
+					}
+					throw pe;
 				}
-			} catch (final PersistenceException pe) {
-				if ((pe.getCause() instanceof final DatabaseException de) && (de.getCause() instanceof final SQLInvalidAuthorizationSpecException ae)) {
-					mapFactories.remove(config);
-					factory.close();
-					throw new DBException(ae);
-				}
-				throw pe;
 			}
 		}
 		return factory;


### PR DESCRIPTION
Wichtiger Hinweis vorab: Dieser PR ist durch meine Anweisungen fast vollständig durch KI generiert worden (Claude Opus 4.6) und die genauen Überlegungen und Entscheidungen der KI kann ich mangels Vertrautheit mit diesen Systemen weder genau nachvollziehen noch bewerten. Deshalb ist der PR in erster Linie als Anregung gedacht, aber vielleicht können Teile ja übernommen werden. Oberflächliche Tests mit SchILD-NRW 3 liefen jedenfalls fehlerfrei und schneller. Für mich war es auch ein Versuch oder Experiment um zu sehen wie weit Claude mit dieser Aufgabe kommt.

## Zusammenfassung

Diese Änderung reduziert die Anzahl der Datenbankabfragen pro SchILD3-Sitzung um ca. **86 %** durch zwei Optimierungen:

1. **In-Memory-Authentifizierungs-Cache** – vermeidet wiederholte DB-Abfragen bei identischen Anmeldedaten
2. **Ratenbegrenzung der Verbindungsvalidierung** – reduziert die pro Aufruf anfallenden `SELECT 1`- und `SET autocommit`-Roundtrips

## Problemstellung

Bei der Nutzung von SchILD3 mit dem SVWS-Server stellte sich heraus, dass jeder REST-Aufruf einen erheblichen Overhead an Datenbankabfragen verursacht:

- **5 Authentifizierungs-/Autorisierungsabfragen** pro REST-Aufruf (immer die gleichen):
  - `SELECT … FROM V_BenutzerDetails` (alle Benutzer laden)
  - `SELECT … FROM V_BenutzerDetails WHERE Benutzername = ?` (einzelner Benutzer)
  - `SELECT … FROM V_Benutzerkompetenzen WHERE Benutzer_ID = ?`
  - `SELECT … FROM Schuljahresabschnitte`
  - `SELECT … FROM EigeneSchule` (Stammdaten)
- **3 Autocommit-Overhead-Queries** pro eigentlicher Abfrage:
  - `SET autocommit=0` → eigentliche Query → `SET autocommit=1`
  - Plus `SELECT 1` zur Verbindungsvalidierung

Eine kurze SchILD3-Sitzung (Anmeldung, Schüler- und Lehrer-Tabs laden) erzeugte **2.130 DB-Operationen**, davon:
- 505 wiederholte Auth-Abfragen (23 %)
- 1.188 Autocommit-/Validierungs-Overhead (54 %)
- Nur ~493 echte Datenabfragen (23 %)

## Lösung

### 1. Authentifizierungs-Cache (`BenutzerAuthCache.java`)

Neuer In-Memory-Cache in `svws-db-utils`, der erfolgreiche Authentifizierungsergebnisse zwischenspeichert:

- **Schlüssel**: Schema + Benutzername (case-insensitive)
- **Wert**: SHA-256-Hash des Passworts + alle Benutzer-/Autorisierungsdaten (Kompetenzen, Stammdaten, Klassen-IDs, Leitungsfunktionen, Abiturjahrgänge)
- **TTL**: 5 Minuten (konfigurierbar über `CACHE_TTL_MS`)
- **Thread-Sicherheit**: `ConcurrentHashMap`
- **Sicherheit**: Passwort wird als SHA-256-Hash gespeichert, nicht im Klartext

Bei einem Cache-Hit werden 0 DB-Abfragen ausgeführt – das `Benutzer`-Objekt wird vollständig aus dem Cache rekonstruiert. Beim ersten Aufruf (Cache Miss) wird normal über die Datenbank authentifiziert und das Ergebnis gespeichert.

Integration in `BenutzerApiPrincipal.login()`:
- Vor dem DB-Zugriff: Cache-Abfrage
- Nach erfolgreicher DB-Authentifizierung: Cache-Speicherung

### 2. Ratenbegrenzung der Verbindungsvalidierung (`ConnectionManager.java`)

Die bisherige Validierung im `ConnectionManager.get()` führte bei **jedem Aufruf** eine transaktionsgestützte Validierung durch:

```java
// Vorher: 3 DB-Roundtrips pro Aufruf
em.getTransaction().begin();   // SET autocommit=0
stmt.executeQuery("SELECT 1"); // SELECT 1
em.getTransaction().commit();  // SET autocommit=1
```

Geändert zu:
- **Ratenbegrenzung**: Validierung nur alle 30 Sekunden statt bei jedem Aufruf
- **Leichtgewichtige Prüfung**: `SELECT 1` als native Query ohne Transaktionsrahmen (kein `SET autocommit=0/1`)

## Profiling-Ergebnisse

Vergleich auf Basis einer identischen SchILD3-Sitzung (Anmeldung, Schüler- und Lehrer-Tabs laden):

| Metrik | Baseline (Original) | + Auth Cache | + Rate-Limited Validation |
|---|---|---|---|
| **Gesamte DB-Operationen** | 2.130 | 647 (−70 %) | **475 (−78 %)** |
| **SQL-Abfragen** | 2.021 | 566 (−72 %) | **293 (−86 %)** |
| Auth-Overhead (5 Queries × N) | 490 | 0 (−100 %) | 0 |
| Autocommit-Overhead | 768 | 0 | 5 |
| SELECT 1 Validierung | 384 | 93 | **2** |

### Zeitlicher Verlauf (Queries pro Sekunde)

- **Baseline**: Spitze bei 151 Queries/s
- **Auth-Cache**: Spitze bei 106 Queries/s
- **+ Rate-Limited**: Spitze bei 94 Queries/s

## Risikobewertung

### Auth-Cache
- **Sicherheit**: Passwort wird nur als SHA-256-Hash gespeichert. Bei Passwortänderung liefert der Cache nach dem nächsten Aufruf einen Miss (Hash stimmt nicht überein) und die DB-Authentifizierung greift.
- **Konsistenz**: TTL von 5 Minuten bedeutet, dass Berechtigungsänderungen spätestens nach 5 Minuten wirksam werden. `BenutzerAuthCache.invalidate(schema, username)` kann bei Bedarf gezielt aufgerufen werden.
- **Abwärtskompatibilität**: Volle Kompatibilität – alle Clients (SchILD3, WebUI) funktionieren unverändert.

### Ratenbegrenzung der Validierung
- **Risiko von Datenverlust**: Keines. DB-Operationen nutzen Transaktionen – sie gelingen vollständig oder werden zurückgerollt.
- **Risiko bei DB-Neustart**: Erkennung einer unterbrochenen Verbindung kann bis zu 30 Sekunden verzögert sein (statt sofort). Die erste fehlschlagende Query löst den Fehlerbehandler aus, der den Connection-Pool zurücksetzt. Der Benutzer muss die Operation wiederholen.
- **MariaDB default `wait_timeout`**: 28.800 Sekunden (8 Stunden). Verbindungen sterben nicht zufällig – das 30-Sekunden-Intervall bietet ausreichend Sicherheitsmarge.

## Geänderte Dateien

| Datei | Änderung |
|---|---|
| `svws-db-utils/.../BenutzerAuthCache.java` | **Neu**: In-Memory-Authentifizierungs-Cache |
| `svws-db-utils/.../BenutzerApiPrincipal.java` | Cache-Integration in `login()` |
| `svws-db/.../ConnectionManager.java` | Ratenbegrenzung der Verbindungsvalidierung |

## Keine Änderungen an

- Datenbank-Schema
- REST-API-Schnittstelle
- Client-Kompatibilität (SchILD3, WebUI, etc.)
- Schreiboperationen oder Transaktionsverhalten