### PR TITLE
Linux-Installer: Reste der Testdaten-Initialisierung entfernt (#505)

### DIFF
--- a/deployment/linux-installer/README.md
+++ b/deployment/linux-installer/README.md
@@ -23,7 +23,14 @@ Folgende Konfigurationen können vorgenommen werden:
 - MariaDB-Konfiguration
 - Installationspfade
 - Erstellung eines Keystores für TLS
-- Import von Testdaten
+
+## Hinweis zu Testdaten
+
+Der Installer legt bewusst keine Testdaten an. Für den produktiven Betrieb
+wird ein leeres Schema erstellt; Testdaten sind nicht mehr Teil des
+Installationspfades. Wer eine befüllte Datenbank für Testzwecke benötigt,
+kann ein bestehendes Schema über den Admin-Client bzw. den Migrations-/
+Import-Endpunkt (`POST /api/schema/import/{schema}/sqlite`) einspielen.
 
 
 ## Wichtige Hinweise

--- a/deployment/linux-installer/install.sh
+++ b/deployment/linux-installer/install.sh
@@ -37,7 +37,6 @@ password1=$(head /dev/urandom | tr -dc $CHARS | fold -w $LENGTH | head -n 1)
 
 export CREATE_MARIADB=J
 export CREATE_KEYSTORE=J
-export CREATE_TESTDATA=J
 export MARIADB_ROOT_PASSWORD=${password1}
 export MARIADB_HOST=localhost
 


### PR DESCRIPTION
## Zusammenfassung

Aufräum-Patch für #505. Laut Rückmeldung von @hmt in [#505](https://github.com/SVWS-NRW/SVWS-Server/issues/505#issuecomment-4279399466) werden vom Installer bewusst keine Testdaten mehr eingespielt; noch vorhandene Reste der alten Testdaten-Initialisierung sollen entfernt werden.

## Änderungen

- **`deployment/linux-installer/install.sh`**: Der ungenutzte `export CREATE_TESTDATA=J` (Zeile 40) wurde entfernt. Die Variable wurde nirgendwo im Skript ausgewertet und war damit irreführend — genau das war der Auslöser für #505.
- **`deployment/linux-installer/README.md`**: Der Listenpunkt „Import von Testdaten" wurde aus den Konfigurationsoptionen entfernt und durch einen kurzen Hinweisabschnitt ersetzt, der klarstellt, dass der Installer keine Testdaten anlegt, und auf den Schema-Import via Admin-Client / `POST /api/schema/import/{schema}/sqlite` verweist.

## Validierung

- `./gradlew build` läuft erfolgreich durch (reine Shell-/Doku-Änderung).
- shellcheck meldet keine neuen Warnungen; vorhandene Warnungen in `install.sh` bleiben unverändert bestehen und sind nicht Gegenstand dieses PRs.

## Hinweis

Falls ein Merge Request in der GitLab-Instanz bevorzugt wird, kann der Branch auch dorthin verschoben werden — kurze Rückmeldung genügt.

Closes #505.