### PR TITLE
Webclient/UI: Kommafehler und Erzieher-Bezeichnung im Lesbarkeits-Hinweis (#513)

### DIFF
--- a/svws-webclient/ui/src/ui/layout/UiLoginLayout.vue
+++ b/svws-webclient/ui/src/ui/layout/UiLoginLayout.vue
@@ -50,7 +50,7 @@
 					<p v-if="!hideHinweis" class="opacity-50 text-sm text-left px-1">
 						Hinweis: Um eine gute Lesbarkeit zu erzeugen, wird bei SVWS-NRW möglichst auf
 						geschlechtsneutrale Begriffe wie Lehrkräfte, Klassenleitung, Erziehungsberechtigte usw.
-						zurückgegriffen. An Stellen, wo das nicht möglich ist, wird versucht alle
+						zurückgegriffen. An Stellen, wo das nicht möglich ist, wird versucht, alle
 						Geschlechter gleichermaßen zu berücksichtigen.
 					</p>
 				</div>

--- a/svws-webclient/ui/src/ui/nav/SvwsUiMenu.vue
+++ b/svws-webclient/ui/src/ui/nav/SvwsUiMenu.vue
@@ -31,8 +31,8 @@
 				</div>
 				<p class="text-left text-ui-secondary">
 					Hinweis: Um eine gute Lesbarkeit zu erzeugen, wird bei SVWS-NRW möglichst auf geschlechtsneutrale
-					Begriffe wie Lehrkräfte, Klassenleitung, Erzieher usw. zurückgegriffen. An Stellen, wo das nicht
-					möglich ist, wird versucht alle Geschlechter gleichermaßen zu berücksichtigen.
+					Begriffe wie Lehrkräfte, Klassenleitung, Erziehungsberechtigte usw. zurückgegriffen. An Stellen, wo das nicht
+					möglich ist, wird versucht, alle Geschlechter gleichermaßen zu berücksichtigen.
 				</p>
 			</div>
 		</template>


### PR DESCRIPTION
## Zusammenfassung

Kleiner Textfix fuer #513. Der Hinweis zur geschlechtsneutralen Sprache erscheint an zwei Stellen im Webclient:

- `svws-webclient/ui/src/ui/nav/SvwsUiMenu.vue` (Hauptmenu)
- `svws-webclient/ui/src/ui/layout/UiLoginLayout.vue` (Login-Layout)

## Aenderungen

1. **Fehlendes Komma** vor der erweiterten Infinitivgruppe ergaenzt. Aus
   `... wird versucht alle Geschlechter gleichermassen zu beruecksichtigen.`
   wird
   `... wird versucht, alle Geschlechter gleichermassen zu beruecksichtigen.`
   (Dies war die urspruengliche Beobachtung im Issue.)

2. **`Erzieher` -> `Erziehungsberechtigte`** in `SvwsUiMenu.vue`.
   Der Login-Text nutzte bereits den neutralen Begriff; das Menue war hier inkonsistent und stand im Widerspruch zum Hinweis selbst.

## Bewusst nicht im Scope

In den Issue-Kommentaren wurden weitere Vorschlaege diskutiert (Ersetzen von verbleibenden `Lehrer`-Nennungen, Umbenennung `Benutzername` -> `dienstliche Mailadresse`, ggf. Entfernen des Hinweises). Das sind aus meiner Sicht eigene, breitere UX-Aenderungen - daher hier bewusst nicht enthalten. Falls gewuenscht, gerne in separaten PRs oder auf Zuruf.

## Validierung

- `./gradlew :svws-webclient:ui:build` laeuft erfolgreich durch.
- Reiner Textfix, keine Logikaenderungen.

Refs #513.