### PR TITLE
fix(core,openapi): Behebung von vier kritischen Fehlern

### DIFF
--- a/svws-openapi/src/main/java/de/svws_nrw/api/common/OpenAPICorsFilter.java
+++ b/svws-openapi/src/main/java/de/svws_nrw/api/common/OpenAPICorsFilter.java
@@ -36,11 +36,23 @@ public final class OpenAPICorsFilter implements ContainerResponseFilter, Contain
 		if (SVWSKonfiguration.get().useCORSHeader()) {
 			final int _ACCESS_CONTROL_MAX_AGE_IN_SECONDS = 12 * 60 * 60;
 			final MultivaluedMap<String, Object> headers = responseContext.getHeaders();
-			headers.add("Access-Control-Allow-Origin", "*");
+			// Hinweis: Die Kombination aus "Access-Control-Allow-Origin: *" und
+			// "Access-Control-Allow-Credentials: true" ist laut CORS-Spezifikation unzulässig
+			// und wird von aktuellen Browsern abgelehnt. Wir spiegeln daher - sofern vorhanden -
+			// den Origin-Header der Anfrage zurück und setzen "Vary: Origin", damit Caches
+			// zwischen unterschiedlichen Ursprüngen unterscheiden. Nur wenn ein Origin
+			// zurückgegeben wird, wird auch "Allow-Credentials" gesendet.
+			final String origin = requestContext.getHeaderString("Origin");
+			if ((origin != null) && !origin.isBlank()) {
+				headers.add("Access-Control-Allow-Origin", origin);
+				headers.add("Vary", "Origin");
+				headers.add("Access-Control-Allow-Credentials", "true");
+			} else {
+				headers.add("Access-Control-Allow-Origin", "*");
+			}
 			headers.add("Access-Control-Allow-Headers", "origin, content-type, accept, authorization");
-			headers.add("Access-Control-Allow-Credentials", "true");
 			headers.add("Access-Control-Allow-Methods", "GET, POST, PATCH, PUT, DELETE, OPTIONS, HEAD");
-			headers.add("Access-Control-Max-Age", _ACCESS_CONTROL_MAX_AGE_IN_SECONDS);
+			headers.add("Access-Control-Max-Age", Integer.toString(_ACCESS_CONTROL_MAX_AGE_IN_SECONDS));
 			headers.add("Access-Control-Expose-Headers", "Content-Disposition");
 		}
 	}

--- a/svws-webclient/core/src/java/lang/JavaString.ts
+++ b/svws-webclient/core/src/java/lang/JavaString.ts
@@ -32,7 +32,11 @@ export abstract class JavaString {
 	}
 
 	public static matches(s: string, regex: string): boolean {
-		const regexp = new RegExp(regex);
+		// Java-Semantik: String.matches verlangt, dass der komplette String dem Muster entspricht.
+		// In JavaScript prüft RegExp.test dagegen auf ein beliebiges Teilstück, daher muss das
+		// Muster hier mit ^ und $ verankert werden. Das zusätzliche "(?:...)" stellt sicher,
+		// dass Alternativen im Muster (z.B. "a|b") korrekt geklammert sind.
+		const regexp = new RegExp("^(?:" + regex + ")$");
 		return regexp.test(s);
 	}
 

--- a/svws-webclient/core/src/java/util/Arrays.ts
+++ b/svws-webclient/core/src/java/util/Arrays.ts
@@ -22,7 +22,16 @@ export class Arrays extends JavaObject {
 	}
 
 	public static copyOf<T>(original: Array<T>, newLength: number): Array<T> {
-		return original.slice();
+		// Entspricht Arrays.copyOf in Java: Das Ergebnis hat genau newLength Elemente.
+		// Wird das Original gekürzt, so werden die überschüssigen Einträge verworfen;
+		// ist newLength größer als die Länge des Originals, werden die fehlenden
+		// Einträge mit null aufgefüllt (entspricht dem Java-Default-Wert für Objekt-Arrays).
+		if (newLength < 0)
+			throw new Error("newLength must not be negative");
+		const copy: Array<T> = original.slice(0, newLength);
+		while (copy.length < newLength)
+			copy.push(null as unknown as T);
+		return copy;
 	}
 
 	public static deepEquals(a1: Array<unknown> | null, a2: Array<unknown> | null): boolean {

--- a/svws-webclient/core/src/java/util/Random.ts
+++ b/svws-webclient/core/src/java/util/Random.ts
@@ -1,28 +1,86 @@
+import { IllegalArgumentException } from '../../java/lang/IllegalArgumentException';
 import { JavaObject } from '../../java/lang/JavaObject';
 
+/**
+ * Typescript-Implementierung, die das Verhalten der Java-Klasse {@link java.util.Random}
+ * emuliert. Anders als bei {@link Math.random} wird hier ein deterministischer
+ * Pseudo-Zufallszahlengenerator (Mulberry32) genutzt, damit die aus dem Java-Quellcode
+ * transpilierten Algorithmen (z.B. Kursblockung, Stundenplanblockung) bei gleichem Seed
+ * reproduzierbare Ergebnisse liefern.
+ */
 export class Random extends JavaObject {
 
+	/** Der interne 32-Bit-Zustand des Mulberry32-Generators. */
+	private _state: number;
+
+	/**
+	 * Erzeugt einen neuen Zufallszahlengenerator. Wird kein Seed übergeben, so wird
+	 * ein zeitbasierter Seed verwendet (analog zu {@link java.util.Random#Random()}).
+	 *
+	 * @param seed   optionaler Seed für reproduzierbare Zufallsfolgen
+	 */
 	public constructor(seed?: number) {
 		super();
-		// TODO use seed - see for example https://github.com/BluSpring/java-util-random/blob/master/src/index.ts
+		// Wenn kein Seed angegeben ist, wird ein zeitbasierter Seed genutzt.
+		const s = (seed === undefined) ? (Date.now() ^ Math.floor(Math.random() * 0xFFFFFFFF)) : seed;
+		// Der Zustand wird auf 32 Bit begrenzt (>>> 0 liefert einen vorzeichenlosen 32-Bit-Wert).
+		this._state = (s | 0) >>> 0;
 	}
 
+	/**
+	 * Liefert die nächste Pseudo-Zufallszahl auf Basis des Mulberry32-Algorithmus.
+	 * Das Ergebnis liegt im Intervall [0, 1).
+	 */
+	private nextFloat(): number {
+		// Mulberry32: einfacher, schneller und qualitativ ausreichender PRNG mit 32 Bit Zustand.
+		this._state = (this._state + 0x6D2B79F5) >>> 0;
+		let t = this._state;
+		t = Math.imul(t ^ (t >>> 15), t | 1);
+		t ^= t + Math.imul(t ^ (t >>> 7), t | 61);
+		return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
+	}
+
+	/**
+	 * Gibt eine pseudo-zufällige nicht-negative ganze Zahl im Bereich [0, bound) zurück.
+	 *
+	 * @param bound   die obere Schranke (exklusiv), muss positiv sein
+	 *
+	 * @throws IllegalArgumentException falls bound nicht positiv ist
+	 */
 	public nextInt(bound: number): number {
-		return Math.floor(Math.random() * Math.floor(bound));
+		// Gemäß Java-Kontrakt muss bound strikt positiv sein.
+		if (bound <= 0)
+			throw new IllegalArgumentException("bound must be positive");
+		return Math.floor(this.nextFloat() * bound);
 	}
 
+	/**
+	 * Gibt eine pseudo-zufällige ganze Zahl zurück. Wird keine Schranke angegeben, so liegt
+	 * das Ergebnis im Bereich der gültigen sicheren Ganzzahlen in JavaScript.
+	 *
+	 * Hinweis: Abweichend von {@link java.util.Random#nextLong()} kann hier aufgrund der
+	 * Begrenzung auf IEEE-754-Double kein vollständiger 64-Bit-Wertebereich abgebildet werden.
+	 *
+	 * @param bound   optionale obere Schranke (exklusiv), muss positiv sein
+	 *
+	 * @throws IllegalArgumentException falls bound angegeben und nicht positiv ist
+	 */
 	public nextLong(bound?: number): number {
-		// TODO using number has drawbacks... bigint as an alternaive has other drawbacks regarding transpiled java code
-		// bound should be less or equal to 9007199254740991
-		return Math.floor(Math.random() * Math.floor((bound === undefined) ? 9007199254740991 : bound));
+		if (bound === undefined)
+			return Math.floor(this.nextFloat() * 9007199254740991);
+		if (bound <= 0)
+			throw new IllegalArgumentException("bound must be positive");
+		return Math.floor(this.nextFloat() * bound);
 	}
 
+	/** Gibt eine pseudo-zufällige Fließkommazahl im Bereich [0.0, 1.0) zurück. */
 	public nextDouble(): number {
-		return Math.random();
+		return this.nextFloat();
 	}
 
+	/** Gibt einen pseudo-zufälligen booleschen Wert zurück. */
 	public nextBoolean(): boolean {
-		return Math.random() < 0.5 ? true: false;
+		return this.nextFloat() < 0.5;
 	}
 
 	public transpilerCanonicalName(): string {


### PR DESCRIPTION
## Zusammenfassung

Dieser PR behebt vier kritische Fehler, die bei einer Triage des Repositories aufgefallen sind. Betroffen sind drei hand-gepflegte Java-Stdlib-Polyfills im TypeScript-Core (`svws-webclient/core/src/java/**`) sowie der CORS-Filter der OpenAPI-Schicht. Alle Änderungen sind mit deutschsprachigen Kommentaren versehen.

## Änderungen

### 1. `svws-webclient/core/src/java/util/Random.ts`
Die bisherige Implementierung hat den Konstruktor-Parameter `seed` ignoriert und intern `Math.random()` verwendet, sodass `new Random(seed)` **nicht** reproduzierbar war. Für die aus Java transpilierten Algorithmen (z.B. Kursblockung, Stundenplanung) ist ein deterministischer PRNG aber zwingend erforderlich.

- Implementierung eines seed-basierten Mulberry32-PRNG (32-Bit-Zustand).
- `nextInt(bound)` und `nextLong(bound)` werfen nun `IllegalArgumentException`, wenn `bound` nicht positiv ist - analog zu `java.util.Random`.
- `nextDouble()` und `nextBoolean()` nutzen den neuen Generator.
- Der bisherige `TODO`-Kommentar zum Seed wurde aufgelöst.

### 2. `svws-webclient/core/src/java/util/Arrays.ts`
`Arrays.copyOf(original, newLength)` hat `newLength` bisher komplett ignoriert und das Eingabe-Array unverändert kopiert. Das Verhalten weicht damit von `java.util.Arrays.copyOf` ab und führt bei Aufrufern, die auf eine bestimmte Ziellänge angewiesen sind, zu falschen Ergebnissen.

- Das Ergebnis hat nun exakt `newLength` Elemente.
- Überschüssige Elemente werden beim Kürzen verworfen, fehlende Elemente mit `null` aufgefüllt (Java-Default für Objekt-Arrays).
- Negative `newLength`-Werte werden abgelehnt.

### 3. `svws-webclient/core/src/java/lang/JavaString.ts`
`JavaString.matches(s, regex)` hat intern `RegExp.test` verwendet und damit bereits bei Teil-Treffern `true` geliefert. `String.matches` in Java erfordert dagegen einen vollständigen Match.

- Das Muster wird nun mit `^(?:...)$` verankert, sodass die Java-Semantik eingehalten wird und Alternativen (`a|b`) korrekt geklammert sind.

### 4. `svws-openapi/.../OpenAPICorsFilter.java`
Der Filter sendet bisher gleichzeitig `Access-Control-Allow-Origin: *` und `Access-Control-Allow-Credentials: true`. Diese Kombination ist laut CORS-Spezifikation unzulässig und wird von aktuellen Browsern (Chrome, Firefox, Safari) abgelehnt, wodurch credential-basierte Cross-Origin-Anfragen fehlschlagen.

- Ist ein `Origin`-Header in der Anfrage vorhanden, wird dieser zurückgespiegelt und zusätzlich `Vary: Origin` gesetzt, damit Caches zwischen unterschiedlichen Ursprüngen unterscheiden.
- `Access-Control-Allow-Credentials: true` wird nur gesendet, wenn ein Origin zurückgegeben wird.
- `Access-Control-Max-Age` wird jetzt als `String` übergeben (statt als `int`), was dem erwarteten Header-Format entspricht.

## Testplan

- Die Änderungen sind lokal syntaktisch geprüft; ein vollständiger Build/Testlauf konnte in der Entwicklungsumgebung nicht ausgeführt werden (kein installierter Dependency-Cache).
- Für die Maintainer bitte mit `./gradlew build` und `npm run -w @svws-nrw/svws-core build test` verifizieren.
- Manuelle Prüfung des CORS-Filters mittels `curl -H "Origin: https://example.test" -I <svws-endpoint>` - im Response darf `Access-Control-Allow-Origin` nicht `*` sein, solange ein Origin gesendet wurde.

## Hinweise für Reviewer

- Der Branch ist auf `dev` rebased und enthält einen einzelnen Commit, sodass er sich für den üblichen Squash-Merge eignet.
- Weitere, nicht-kritische Fehler (u.a. `HashMap.putAll`-Kurzschluss, Pfad-Typo `@Path("/guppe/remove")`, `JavaString.compareTo` Locale-Verhalten) sind in einem separaten Triage-Bericht dokumentiert und können bei Interesse in Folge-PRs adressiert werden.